### PR TITLE
feat: add reuse compliance

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Digg
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 ---
 name: Build and Deploy
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Digg
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,7 @@
-# SPDX-FileCopyrightText: Digg
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: CC0-1.0
+
 ---
 name: MegaLinter
 on: [workflow_call] # yamllint disable-line rule:truthy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 ---
 name: Unit Tests and Code Coverage
 

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Digg
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
 #
 # SPDX-License-Identifier: CC0-1.0
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/.prettierrc.license
+++ b/.prettierrc.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,0 +1,8 @@
+
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: jitsi-moderator
+Source: https://github.com/diggsweden/jitsi-moderator
+
+Files: *.png *.svg *.ico
+Copyright: 2023 Havs- och vattenmyndigheten
+License: CC0-1.0

--- a/.vscode/settings.json.license
+++ b/.vscode/settings.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Current maintainers. A mix of asom and Digg-representatives
 
 -   @danneleaf @janderssonse @Ayko1595

--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: CC0-1.0
 
 = Contributor Covenant Code of Conduct
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: CC0-1.0
+
 = Contributing
 :toc:
 :revdate: {docdatetime}

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # Governance
 
 Decisions related to the project's direction, new features, and significant changes are made through a consensus-based process involving the maintainers and contributors.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
+<!--
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # Jitsi Moderator
+
+[![REUSE status](https://api.reuse.software/badge/github.com/diggsweden/jitsi-moderator)](https://api.reuse.software/info/github.com/diggsweden/jitsi-moderator)
 
 **Description**:
 A React Vite app that adds more features on top of Jitsi to help manage meetings through an intuitive dashboard. It allows you to either connect to a meeting by pasting the url or to create an entirely new meeting.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 # Security Reporting
 
 If you wish to report a security vulnerability but not in a public issue -- thank you!

--- a/development/code_quality.sh
+++ b/development/code_quality.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# SPDX-FileCopyrightText: 2023 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
 # Run a code quality check
 
 declare -A EXITCODES
@@ -70,6 +74,13 @@ commit() {
     printf '\n\n'
 }
 
+license() {
+    print_header 'LICENSE HEALTH (REUSE)'
+    podman run --rm --volume "$(pwd)":/data docker.io/fsfe/reuse:2-debian lint
+    store_exit_code "$?" "License" "${MISSING} ${RED}License check failed, see logs and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} License check passed${NC}\n"
+    printf '\n\n'
+}
+
 coverage() {
     print_header 'COVERAGE (V8)'
     (
@@ -108,6 +119,7 @@ is_command_available 'npm' 'https://nodejs.org/'
 
 lint_and_format
 commit
+license
 coverage
 
 check_exit_codes

--- a/development/mega-linter.yml
+++ b/development/mega-linter.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+#
+# SPDX-License-Identifier: CC0-1.0
+
 ---
 # Configuration file for MegaLinter.
 # See configuration options at https://oxsecurity.github.io/megalinter/configuration/ and more in each linter documentation.

--- a/index.html
+++ b/index.html
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0
+-->
+
 <!DOCTYPE html>
 <html lang="en">
 	<head>

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0

--- a/public/locales/en/translation.json.license
+++ b/public/locales/en/translation.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0

--- a/public/locales/sv/translation.json.license
+++ b/public/locales/sv/translation.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import "./i18n";
 import JitsiProApp from "./components/JitsiProApp";
 import GlobalStyle from "./utils/styles/GlobalStyle";

--- a/src/__tests__/helpers/chatHelper.test.ts
+++ b/src/__tests__/helpers/chatHelper.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { shouldSendMessageToCurrentRoom } from "../../utils/helpers/chatHelper";
 import BreakoutRoom from "../../utils/interfaces/BreakoutRoom";
 

--- a/src/__tests__/helpers/configHelper.test.ts
+++ b/src/__tests__/helpers/configHelper.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	createJitsiMeetingInfoFromConfig,
 	getRandomMeetingName,

--- a/src/__tests__/helpers/roomHelper.test.ts
+++ b/src/__tests__/helpers/roomHelper.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	breakoutRoomsArrayContainsRoom,
 	breakoutRoomsObjectContainsRoom,

--- a/src/__tests__/helpers/urlHelper.test.ts
+++ b/src/__tests__/helpers/urlHelper.test.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {
 	createMeetingUrlFromJitsiMeetingInfo,
 	getJitsiMeetingInfoFromUrlParams,

--- a/src/components/AppContainer.tsx
+++ b/src/components/AppContainer.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Theme from "../utils/styles/Theme";
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { css, styled } from "styled-components";
 import Theme from "../utils/styles/Theme";
 

--- a/src/components/ChatBox.tsx
+++ b/src/components/ChatBox.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import Theme from "../utils/styles/Theme";
 

--- a/src/components/FieldSet.tsx
+++ b/src/components/FieldSet.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import Theme from "../utils/styles/Theme";
 

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled, { css } from "styled-components";
 import Theme from "../utils/styles/Theme";
 

--- a/src/components/JitsiMeetContainer.tsx
+++ b/src/components/JitsiMeetContainer.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Card from "./Card";
 import { JitsiMeeting } from "@jitsi/react-sdk";

--- a/src/components/JitsiProApp.tsx
+++ b/src/components/JitsiProApp.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Outlet } from "react-router-dom";
 
 const JitsiProApp = () => {

--- a/src/components/MessageOverlay.tsx
+++ b/src/components/MessageOverlay.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Theme from "../utils/styles/Theme";
 import { H3 } from "./Typography";

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { css, styled } from "styled-components";
 import Theme, { ColorType } from "../utils/styles/Theme";
 

--- a/src/components/breakout-rooms-dropdown/BreakoutRoomsDropdown.tsx
+++ b/src/components/breakout-rooms-dropdown/BreakoutRoomsDropdown.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import { DropdownIconButton } from "../buttons/DropdownIconButton";
 import { useContext, useEffect, useState } from "react";

--- a/src/components/breakout-rooms-dropdown/BreakoutRoomsDropdownMenu.tsx
+++ b/src/components/breakout-rooms-dropdown/BreakoutRoomsDropdownMenu.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled, { css } from "styled-components";
 import BreakoutRoom from "../../utils/interfaces/BreakoutRoom";
 import { useState, useRef, useEffect } from "react";

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled, { css } from "styled-components";
 import RootButton from "./RootButton";
 import ButtonStyles, { ButtonType } from "../../utils/styles/ButtonStyles";

--- a/src/components/buttons/ButtonGrid.tsx
+++ b/src/components/buttons/ButtonGrid.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Theme from "../../utils/styles/Theme";
 

--- a/src/components/buttons/DropdownIconButton.tsx
+++ b/src/components/buttons/DropdownIconButton.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import RootButton from "./RootButton";
 import Theme from "../../utils/styles/Theme";

--- a/src/components/buttons/DropdownListItemButton.tsx
+++ b/src/components/buttons/DropdownListItemButton.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import Check from "../../icons/14/check-14.svg?react";
 import Theme from "../../utils/styles/Theme";

--- a/src/components/buttons/RootButton.tsx
+++ b/src/components/buttons/RootButton.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled, { css } from "styled-components";
 import { ButtonSizes } from "../../utils/styles/ButtonStyles";
 import Theme from "../../utils/styles/Theme";

--- a/src/components/dialog/DialogContent.tsx
+++ b/src/components/dialog/DialogContent.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Theme from "../../utils/styles/Theme";
 

--- a/src/components/dialog/DialogHeader.tsx
+++ b/src/components/dialog/DialogHeader.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Theme from "../../utils/styles/Theme";
 

--- a/src/components/dialog/JitsiMeetErrorDialog.tsx
+++ b/src/components/dialog/JitsiMeetErrorDialog.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Theme from "../../utils/styles/Theme";
 import Card from "../Card";

--- a/src/components/dialog/JitsiMeetInputDialog.tsx
+++ b/src/components/dialog/JitsiMeetInputDialog.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import styled from "styled-components";

--- a/src/components/divider/LabeledDivider.tsx
+++ b/src/components/divider/LabeledDivider.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import SectionDivider from "./SectionDivider";
 import { Label } from "../Typography";

--- a/src/components/divider/SectionDivider.tsx
+++ b/src/components/divider/SectionDivider.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import Theme, { ColorType } from "../../utils/styles/Theme";
 

--- a/src/components/info-cards/ChatInfoCard.tsx
+++ b/src/components/info-cards/ChatInfoCard.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import InfoCard from "./InfoCard";
 import BreakoutRoom from "../../utils/interfaces/BreakoutRoom";

--- a/src/components/info-cards/InfoCard.tsx
+++ b/src/components/info-cards/InfoCard.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { css, styled } from "styled-components";
 import Theme, { ColorType } from "../../utils/styles/Theme";
 

--- a/src/components/info-cards/WarningInfoCard.tsx
+++ b/src/components/info-cards/WarningInfoCard.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import InfoCard from "./InfoCard";
 import { H3, Paragraph } from "../Typography";

--- a/src/components/loaders/JitsiProgress.tsx
+++ b/src/components/loaders/JitsiProgress.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled, { keyframes } from "styled-components";
 import Theme from "../../utils/styles/Theme";
 

--- a/src/components/loaders/JitsiSpinner.tsx
+++ b/src/components/loaders/JitsiSpinner.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled, { keyframes } from "styled-components";
 
 const JitsiSpinner = () => {

--- a/src/components/side-panel/SidePanel.tsx
+++ b/src/components/side-panel/SidePanel.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import Card from "../Card";
 import JitsiCommandSection from "./sections/JitsiCommandsSection";

--- a/src/components/side-panel/sections/ChatSection.tsx
+++ b/src/components/side-panel/sections/ChatSection.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import FieldSet, { Legend } from "../../FieldSet";
 import { useContext, useEffect, useState } from "react";

--- a/src/components/side-panel/sections/CommandSection.tsx
+++ b/src/components/side-panel/sections/CommandSection.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { css, styled } from "styled-components";
 
 interface ICommandSection {

--- a/src/components/side-panel/sections/InviteSection.tsx
+++ b/src/components/side-panel/sections/InviteSection.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Button from "../../buttons/Button";
 import ButtonGrid from "../../buttons/ButtonGrid";
 import { TitledCommandSection } from "./TitledCommandSection";

--- a/src/components/side-panel/sections/JitsiCommandsSection.tsx
+++ b/src/components/side-panel/sections/JitsiCommandsSection.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useTranslation } from "react-i18next";
 import { JitsiCommands } from "../../../utils/enums/JitsiCommands";
 import ButtonGrid from "../../buttons/ButtonGrid";

--- a/src/components/side-panel/sections/TitledCommandSection.tsx
+++ b/src/components/side-panel/sections/TitledCommandSection.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import { H3, Ingress } from "../../Typography";
 import Theme from "../../../utils/styles/Theme";

--- a/src/components/side-panel/sections/breakout-rooms/BreakoutRoomItem.tsx
+++ b/src/components/side-panel/sections/breakout-rooms/BreakoutRoomItem.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled, { css } from "styled-components";
 import User from "../../../../icons/14/user-14.svg?react";
 import { Label } from "../../../Typography";

--- a/src/components/side-panel/sections/breakout-rooms/BreakoutRoomsList.tsx
+++ b/src/components/side-panel/sections/breakout-rooms/BreakoutRoomsList.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import styled from "styled-components";
 import BreakoutRoom from "../../../../utils/interfaces/BreakoutRoom";
 import BreakoutRoomsItem from "./BreakoutRoomItem";

--- a/src/components/side-panel/sections/breakout-rooms/BreakoutRoomsSection.tsx
+++ b/src/components/side-panel/sections/breakout-rooms/BreakoutRoomsSection.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { styled } from "styled-components";
 import { JitsiCommands } from "../../../../utils/enums/JitsiCommands";
 import SectionDivider from "../../../divider/SectionDivider";

--- a/src/context/jitsiContext.ts
+++ b/src/context/jitsiContext.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { createContext } from "react";
 import IExtendedJitsiMeetExternalApi from "../utils/interfaces/IExtendedJitsiMeetExternalApi";
 import BreakoutRoom from "../utils/interfaces/BreakoutRoom";

--- a/src/declarations/config.d.ts
+++ b/src/declarations/config.d.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 interface Config {
 	domain: string;
 }

--- a/src/declarations/vite-env-override.d.ts
+++ b/src/declarations/vite-env-override.d.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 declare module "*.svg" {
 	const content: React.FC<React.SVGProps<SVGElement>>;
 	export default content;

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";

--- a/src/routes/Error.tsx
+++ b/src/routes/Error.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useNavigate } from "react-router-dom";
 import GlobalStyle from "../utils/styles/GlobalStyle";
 import AppContainer from "../components/AppContainer";

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useNavigate } from "react-router-dom";
 import { createJitsiMeetingInfoFromConfig } from "../utils/helpers/configHelper";
 import {

--- a/src/routes/Meeting.tsx
+++ b/src/routes/Meeting.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState, useRef } from "react";
 import {
 	LoaderFunction,

--- a/src/utils/api/JitsiApi.ts
+++ b/src/utils/api/JitsiApi.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { JitsiCommands } from "../enums/JitsiCommands";
 import { JitsiEvents } from "../enums/JitsiEvents";
 import { IBreakoutRoomsUpdated } from "../hooks/useBreakoutRoomsUpdated";

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 type SizesType =
 	| "mobileS"
 	| "mobileM"

--- a/src/utils/enums/JitsiCommands.ts
+++ b/src/utils/enums/JitsiCommands.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export enum JitsiCommands {
 	MUTE_EVERYONE = "muteEveryone",
 	ADD_BREAKOUT_ROOM = "addBreakoutRoom",

--- a/src/utils/enums/JitsiEvents.ts
+++ b/src/utils/enums/JitsiEvents.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export enum JitsiEvents {
 	VIDEO_CONFERENCE_JOINED = "videoConferenceJoined",
 	PARTICIPANT_ROLE_CHANGED = "participantRoleChanged",

--- a/src/utils/enums/Routes.ts
+++ b/src/utils/enums/Routes.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 enum Routes {
 	ROOT = "/",
 	HOME = "",

--- a/src/utils/helpers/chatHelper.ts
+++ b/src/utils/helpers/chatHelper.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import BreakoutRoom from "../interfaces/BreakoutRoom";
 
 export const shouldSendMessageToCurrentRoom = (

--- a/src/utils/helpers/configHelper.ts
+++ b/src/utils/helpers/configHelper.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { JitsiMeetingInfo } from "../interfaces/JitsiMeetingInfo";
 
 const DEFAULT_JITSI_DOMAIN = "meet.jit.si";

--- a/src/utils/helpers/roomHelper.ts
+++ b/src/utils/helpers/roomHelper.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import BreakoutRoom, { BreakoutRooms } from "../interfaces/BreakoutRoom";
 import Participant, { Participants } from "../interfaces/Participant";
 

--- a/src/utils/helpers/urlHelper.ts
+++ b/src/utils/helpers/urlHelper.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Routes, { QueryParams } from "../enums/Routes";
 import { JitsiMeetingInfo } from "../interfaces/JitsiMeetingInfo";
 

--- a/src/utils/hooks/useBreakoutRoomsUpdated.ts
+++ b/src/utils/hooks/useBreakoutRoomsUpdated.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useState } from "react";
 import { JitsiEvents } from "../enums/JitsiEvents";
 import IExtendedJitsiMeetExternalApi from "../interfaces/IExtendedJitsiMeetExternalApi";

--- a/src/utils/hooks/useOutsideClick.ts
+++ b/src/utils/hooks/useOutsideClick.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useRef } from "react";
 
 interface IOutsideClick {

--- a/src/utils/hooks/useParticipantRoleChanged.ts
+++ b/src/utils/hooks/useParticipantRoleChanged.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useState } from "react";
 import { JitsiEvents } from "../enums/JitsiEvents";
 import IExtendedJitsiMeetExternalApi from "../interfaces/IExtendedJitsiMeetExternalApi";

--- a/src/utils/hooks/useVideoConferenceJoined.ts
+++ b/src/utils/hooks/useVideoConferenceJoined.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { useEffect, useState } from "react";
 import { JitsiEvents } from "../enums/JitsiEvents";
 import IExtendedJitsiMeetExternalApi from "../interfaces/IExtendedJitsiMeetExternalApi";

--- a/src/utils/interfaces/BreakoutRoom.ts
+++ b/src/utils/interfaces/BreakoutRoom.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { Participants } from "./Participant";
 
 interface BreakoutRoom {

--- a/src/utils/interfaces/IExtendedJitsiMeetExternalApi.ts
+++ b/src/utils/interfaces/IExtendedJitsiMeetExternalApi.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 // We create this extended interface because
 // the IJitsiMeetExternalApi interface used in Jitsi's React SDK does not include getRoomsInfo()
 

--- a/src/utils/interfaces/JitsiMeetingInfo.ts
+++ b/src/utils/interfaces/JitsiMeetingInfo.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export interface JitsiMeetingInfo {
 	domain: string;
 	roomName: string;

--- a/src/utils/interfaces/JitsiNotification.ts
+++ b/src/utils/interfaces/JitsiNotification.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 type JitsiNotificationType = "normal" | "success" | "warning" | "error";
 
 type JitsiNotificationTimeout = "short" | "medium" | "long" | "sticky";

--- a/src/utils/interfaces/Participant.ts
+++ b/src/utils/interfaces/Participant.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export type Role = "none" | "participant" | "moderator";
 
 interface Participant {

--- a/src/utils/interfaces/RoomsInfo.ts
+++ b/src/utils/interfaces/RoomsInfo.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Participant from "./Participant";
 
 interface Room {

--- a/src/utils/styles/ButtonStyles.ts
+++ b/src/utils/styles/ButtonStyles.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import Theme from "./Theme";
 
 export type ButtonSizes = "s" | "m" | "l";

--- a/src/utils/styles/GlobalStyle.ts
+++ b/src/utils/styles/GlobalStyle.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { createGlobalStyle } from "styled-components";
 import devices from "../devices";
 import Theme from "./Theme";

--- a/src/utils/styles/Theme.ts
+++ b/src/utils/styles/Theme.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /* eslint-disable sort-keys */
 interface Color {
 	normal: string;

--- a/tsconfig.json.license
+++ b/tsconfig.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+
+SPDX-License-Identifier: CC0-1.0

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,2 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 /// <reference types="./src/declarations/vite-env-override.d.ts" />
 /// <reference types="vite/client" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 Havs- och vattenmyndigheten
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import svgr from "vite-plugin-svgr";


### PR DESCRIPTION
Makes the project reuse compliant https://reuse.software/ and fixes the broken CI regarding license lint.
Should be merged after https://github.com/diggsweden/jitsi-moderator/pull/16 and https://github.com/diggsweden/jitsi-moderator/pull/17 (that will also lessen the shown github-diff for this one).

@Ayko1595 Question till further PR (let's fix those in future prs if not correct no need to change this pr) - are the images correct to be under CC0-license, or should they be copyrighted to someone else?

Fixes #8

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
